### PR TITLE
Check to see if stafi version came back empty

### DIFF
--- a/stats.sh
+++ b/stats.sh
@@ -172,6 +172,10 @@ alert=false
 
 if [[ "$system_version" == "$stafi_system_version" ]]; then
   version_msg="Same Version"
+
+elif [[ "$stafi_system_version" == "" ]]; then
+version_msg="Stafi version unknown"
+  
 else
 version_msg="❌ Wrong Version: stafi is $stafi_system_version and yours is $system_version"
 version_alert=true


### PR DESCRIPTION
Did a simple check to see if the stafi version is empty meaning in simple terms that the RPC failed. Easiest and quickest fix rather than checking for HTTP status codes.